### PR TITLE
Added empty package

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -1,0 +1,2 @@
+package gofork
+


### PR DESCRIPTION
Hi,

A simple PR as `go get` (and `dep`) fail to retrieve a project which has no go file at its root.

Thanks for your work,
Flo